### PR TITLE
feat: load templates

### DIFF
--- a/scripts/ak.js
+++ b/scripts/ak.js
@@ -65,6 +65,17 @@ export async function loadBlock(block) {
   return block;
 }
 
+function loadTemplate() {
+  const template = getMetadata('template');
+  if (!template) return;
+  const { codeBase } = getConfig();
+  document.body.classList.add('has-template');
+  loadStyle(`${codeBase}/templates/${template}/${template}.css`).then(() => {
+    document.body.classList.add(`${template}-template`);
+    document.body.classList.remove('has-template');
+  });
+}
+
 function decoratePictures(el) {
   const pics = el.querySelectorAll('picture');
   for (const pic of pics) {
@@ -260,7 +271,10 @@ export async function loadArea({ area } = { area: document }) {
   const { decorateArea } = getConfig();
   if (decorateArea) decorateArea({ area });
   const isDoc = area === document;
-  if (isDoc) decorateHeader();
+  if (isDoc) {
+    loadTemplate();
+    decorateHeader();
+  }
   const sections = decorateSections(area, isDoc);
   for (const [idx, section] of sections.entries()) {
     loadIcons(section);
@@ -276,10 +290,6 @@ export async function loadArea({ area } = { area: document }) {
   // Setup scheme
   const scheme = localStorage.getItem('color-scheme');
   if (scheme) document.body.classList.add(scheme);
-
-  // Setup template
-  const template = getMetadata('template');
-  if (template) { document.body.classList.add(`${template}-template`); }
 
   // Detect Hash
   const pageId = window.location.hash?.replace('#', '');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -392,7 +392,8 @@ svg {
 }
 
 main>div,
-div[data-status] {
+div[data-status],
+.has-template {
   display: none;
 }
 


### PR DESCRIPTION
Introduces a new _synchronous_ `loadTemplate` function.

`loadTemplate` is synchronous (as opposed to async) so we do not await and block other resources. This allows the template css to load in parallel with everything else... icons in LCP, blocks in LCP, etc.

Because a template CSS can land before _or_ after LCP is done, we have introduced a new `.has-template` body class. It will prevent any DOM from showing in case other pieces land (LCP block) before the template is finished loading.